### PR TITLE
should have meta-spec version if using version 2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,8 +33,9 @@ WriteMakefile
 		    'Test::More'   => 1.001014,
 		   },
 
+ LICENSE => 'perl',
  META_MERGE => {
-     license          => "perl_5",
+     'meta-spec' => { version => 2 },
      resources        => {
 	 repository   => {
 	     type => 'git',


### PR DESCRIPTION
Also there is separate argument for license in call for WriteMakefile.