### PR TITLE
Fix converting old irealbook format

### DIFF
--- a/lib/Data/iRealPro/Song.pm
+++ b/lib/Data/iRealPro/Song.pm
@@ -80,7 +80,7 @@ sub parse {
     $tokstring = $self->{raw};
 
     # Correct for iReal key transposition.
-    if ( $self->{actual_key} eq '' ) {
+    if ( $self->{variant} eq "irealbook" || $self->{actual_key} eq '' ) {
 	$self->{_transpose} = 0;
     }
     else {


### PR DESCRIPTION
It does not set actual_key field. Accessing it aborts eval due to strict warnings.