### PR TITLE
Delete missing pp/README from MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -61,4 +61,3 @@ pp/windows/GNUmakefile
 pp/windows/irealcvt.pp
 pp/common/irealcvt.pp
 pp/common/PDF_API2_Bundle.pm
-pp/README


### PR DESCRIPTION
It causes this configure warning:
```
Checking if your kit is complete...
Warning: the following files are missing in your kit:
        pp/README
Please inform the author.
```